### PR TITLE
Build and push ARM64 compatible image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,12 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: setup docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: cache for linux
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: runner.os == 'Linux'
         with:
           path: |
@@ -33,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -42,6 +44,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=~/.cache/go-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - v*
 env:
   REGISTRY: ghcr.io
-  REGISTRY_IMAGE: ghcr.io/Recidiviz/go-zetasql
+  REGISTRY_IMAGE: ghcr.io/recidiviz/go-zetasql
 
 jobs:
   build-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,11 @@ jobs:
           - os: ubuntu-latest
             artifact_name: go-zetasql
             asset_name: go-zetasql-linux-amd64
+            platform: linux/amd64
           - os: macos-latest
             artifact_name: go-zetasql
             asset_name: go-zetasql-darwin-arm64
+            platform: linux/arm64
     steps:
       - uses: actions/checkout@v4
       - uses: docker/metadata-action@v3
@@ -57,12 +59,71 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v6
+        name: Build and push by digest
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          platforms: ${{ matrix.platform }}
           cache-from: type=local,src=~/.cache/go-build
           build-args: |
             VERSION=v${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build-image
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - v*
+
 env:
   REGISTRY: ghcr.io
   REGISTRY_IMAGE: ghcr.io/recidiviz/go-zetasql
@@ -83,6 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-image
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - v*
 env:
   REGISTRY: ghcr.io
+  REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ github.repository }}
 
 jobs:
   build-image:
@@ -25,13 +26,6 @@ jobs:
             platform: linux/arm64
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/metadata-action@v3
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/Recidiviz/go-zetasql
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
       - name: setup docker buildx
         uses: docker/setup-buildx-action@v3
       - name: cache for linux
@@ -97,12 +91,6 @@ jobs:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,14 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/build-push-action@v6
         name: Build and push by digest
+        id: build
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ github.sha }}-${{ matrix.asset_name }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ matrix.platform }}
           cache-from: type=local,src=~/.cache/go-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - v*
 env:
   REGISTRY: ghcr.io
-  REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ github.repository }}
+  REGISTRY_IMAGE: ghcr.io/Recidiviz/go-zetasql
 
 jobs:
   build-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,6 @@ jobs:
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ matrix.platform }}
           cache-from: type=local,src=~/.cache/go-build
-          build-args: |
-            VERSION=v${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
 
       - name: Export digest
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ env:
   REGISTRY_IMAGE: ghcr.io/recidiviz/go-zetasql
 
 jobs:
+  # For each platform in the matrix, creates and pushes a platform-compatible Docker image to the registry
+  # and stores all the image digests as Github Actions build output artifacts so that we can referenced them
+  # in the `merge-platform-images` job below
   build-image:
     runs-on: ubuntu-latest
     permissions:
@@ -80,7 +83,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
+  # Creates a multi-architecture image manifest from the digests of the individual images built above.
+  # This produces a single image tag that contains all the platform-specific images.
+  merge-platform-images:
     runs-on: ubuntu-latest
     needs:
       - build-image
@@ -117,6 +122,7 @@ jobs:
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        # Extract image tags from the metadata action output and create a manifest list
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{matrix.asset_name}}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-${{matrix.asset_name}}-
       - name: cache for macOS
         uses: actions/cache@v3
         if: runner.os == 'macOS'
@@ -46,9 +46,9 @@ jobs:
           path: |
             ~/Library/Caches/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{matrix.asset_name}}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-${{matrix.asset_name}}
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,15 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: go-zetasql
+            asset_name: go-zetasql-linux-amd64
+          - os: macos-latest
+            artifact_name: go-zetasql
+            asset_name: go-zetasql-darwin-arm64
     steps:
       - uses: actions/checkout@v4
       - uses: docker/metadata-action@v3
@@ -21,8 +30,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: setup docker buildx
         uses: docker/setup-buildx-action@v3
       - name: cache for linux
@@ -31,6 +38,16 @@ jobs:
         with:
           path: |
             ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: cache for macOS
+        uses: actions/cache@v3
+        if: runner.os == 'macOS'
+        with:
+          path: |
+            ~/Library/Caches/go-build
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
@@ -44,7 +61,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=~/.cache/go-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ github.sha }}-${{ matrix.asset_name }}
+          tags: ${{ env.REGISTRY_IMAGE }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           platforms: ${{ matrix.platform }}
           cache-from: type=local,src=~/.cache/go-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.asset_name }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -97,6 +97,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and releasing Docker images. The changes improve platform support, enhance caching, and streamline the build and release process by introducing a matrix strategy and additional steps for managing image digests and manifests.

### Workflow Enhancements

* **Matrix Strategy for Multi-Platform Builds**: Introduced a matrix strategy in the `build-image` job to support building images for both `linux/amd64` and `linux/arm64` platforms. This ensures compatibility with a wider range of systems.
* **New Merge Job**: Added a `merge` job to handle digest downloads, metadata generation, and manifest list creation, ensuring that multi-platform images are correctly assembled and pushed.

### Dependency Updates

* **Updated Actions Versions**: Upgraded several GitHub Actions, including `docker/setup-buildx-action` to v3, `actions/cache` to v4, `docker/login-action` to v3, and `docker/build-push-action` to v6, for improved performance and compatibility.

### Caching Improvements

* **Platform-Specific Cache Keys**: Enhanced caching by using platform-specific cache keys (`${{matrix.asset_name}}`) for both Linux and macOS, reducing potential cache conflicts.