### PR TITLE
Pin all GitHub Actions to SHA refs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
             asset_name: go-zetasql-darwin-arm64
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: setup docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: cache for linux
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: runner.os == 'Linux'
         with:
           path: |
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{matrix.asset_name}}-
       - name: cache for macOS
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: runner.os == 'macOS'
         with:
           path: |
@@ -52,13 +52,13 @@ jobs:
           key: ${{ runner.os }}-go-${{matrix.asset_name}}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{matrix.asset_name}}
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         name: Build and push by digest
         id: build
         with:
@@ -76,7 +76,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ matrix.asset_name }}
           path: ${{ runner.temp }}/digests/*
@@ -94,16 +94,16 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions from mutable tags to immutable SHA commit refs
- Prevents tag-moving supply chain attacks (e.g., xygeni/xygeni-action compromise)

## Changes
- `go.yml`: Pin `actions/checkout@v4`, `actions/setup-go@v4` to SHAs
- `release.yml`: Pin `actions/checkout@v4`, `docker/setup-buildx-action@v3`, `actions/cache@v3`/`@v4`, `docker/login-action@v2`/`@v3`, `docker/build-push-action@v6`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `docker/metadata-action@v5` to SHAs

## Test plan
- [ ] Go CI and release workflows still pass
- [ ] No functional changes — only reference format changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)